### PR TITLE
Notifications Feature enabled

### DIFF
--- a/imports/api/@users/user.js
+++ b/imports/api/@users/user.js
@@ -45,6 +45,12 @@ Users.schema.UserProfile = {
     contextId: Schemas.Id,
     context: {type: String},
     count: {type: SimpleSchema.Integer},
+    title: {type: String, optional: true},
+    unSeenIndexes: { type: Array, defaultValue: [], optional: true},
+    'unSeenIndexes.$': {
+      type: SimpleSchema.Integer,
+      optional: true
+    },
   }), optional: true },
 
   attending: { type: Array, optional: true},

--- a/imports/api/chats/chat.methods.js
+++ b/imports/api/chats/chat.methods.js
@@ -36,7 +36,7 @@ Meteor.methods({
     }
     const host = getHost(this);
 
-    const unSeenIndex = Chats.findOne({ contextId: values.contextId }).messages.length;
+    const unSeenIndex = Chats.findOne({ contextId: values.contextId })?.messages?.length;
 
     try {
       Chats.update(
@@ -57,18 +57,15 @@ Meteor.methods({
           },
         }
       );
-      if (values.contextType === 'activity') {
-        return;
-      }
-      if (values.contextType = 'process') {
-        Meteor.call('createProcessNotifications', values, unSeenIndex);
+      if (values.context === 'process') {
+        Meteor.call('createProcessNotification', values, unSeenIndex);
       }
     } catch (error) {
       throw new Meteor.Error(error);
     }
   },
 
-  createProcessNotifications(values, unSeenIndex) {
+  createProcessNotification(values, unSeenIndex) {
     const user = Meteor.user();
     if (!user) {
       throw new Meteor.Error('Not allowed!');

--- a/imports/api/chats/chat.methods.js
+++ b/imports/api/chats/chat.methods.js
@@ -93,18 +93,17 @@ Meteor.methods({
         if (contextIdIndex !== -1) {
           const notifications = [...member.notifications];
           notifications[contextIdIndex].count += 1;
-          // if (!notifications[contextIdIndex].unSeenIndexes) {
-          //   return;
-          // }
+          if (!notifications[contextIdIndex].unSeenIndexes) {
+            notifications[contextIdIndex].unSeenIndexes = []
+          }
           
-          notifications[contextIdIndex].unSeenIndexes.push(unSeenIndex);
+          notifications[contextIdIndex].unSeenIndexes?.push(unSeenIndex);
           Meteor.users.update(member._id, {
             $set: {
               notifications: notifications,
             },
           });
         } else {
-          console.log('here', theProcess.title)
           Meteor.users.update(member._id, {
             $push: {
               notifications: {

--- a/imports/ui/LayoutContainer.jsx
+++ b/imports/ui/LayoutContainer.jsx
@@ -46,29 +46,6 @@ import { chakraTheme } from './@/constants/theme';
 
 const publicSettings = Meteor.settings.public;
 
-const menu = [
-  {
-    label: 'Activities',
-    route: '/',
-  },
-  {
-    label: 'Processes',
-    route: '/processes',
-  },
-  {
-    label: 'Calendar',
-    route: '/calendar',
-  },
-  {
-    label: 'Works',
-    route: '/works',
-  },
-  {
-    label: 'Info',
-    route: `/page/about`,
-  },
-];
-
 const getRoute = (item, index) => {
   if (index === 0) {
     return '/';
@@ -77,17 +54,6 @@ const getRoute = (item, index) => {
     return '/page/about';
   }
   return `/${item.name}`;
-};
-
-const getGotoPath = (pathname) => {
-  const shortPath = pathname.substring(0, 3);
-  if (shortPath === '/pr') {
-    return '/processes';
-  } else if (pathname.includes('/work/')) {
-    return '/works';
-  } else {
-    return '/';
-  }
 };
 
 const getBackgroundStyle = (cHue) => {
@@ -128,7 +94,7 @@ function LayoutPage({
   children,
 }) {
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
-  const [ tc ] = useTranslation('common');
+  const [tc] = useTranslation('common');
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -237,23 +203,33 @@ function LayoutPage({
                   <form action="https://formspree.io/f/xdopweon" method="POST">
                     <ModalBody>
                       <VStack spacing="6">
-                        <FormField label={tc('modals.feedback.form.email.label')}>
+                        <FormField
+                          label={tc('modals.feedback.form.email.label')}
+                        >
                           <Input type="email" name="_replyto" />
                         </FormField>
 
-                        <FormField label={tc('modals.feedback.form.subject.label')}>
+                        <FormField
+                          label={tc('modals.feedback.form.subject.label')}
+                        >
                           <Select name="subject">
-                            {[tc('modals.feedback.form.subject.select.suggest'), tc('modals.feedback.form.subject.select.bug'), tc('modals.feedback.form.subject.select.compliment')].map(
-                              (option) => (
-                                <option key={option} value={option}>
-                                  {option}
-                                </option>
-                              )
-                            )}
+                            {[
+                              tc('modals.feedback.form.subject.select.suggest'),
+                              tc('modals.feedback.form.subject.select.bug'),
+                              tc(
+                                'modals.feedback.form.subject.select.compliment'
+                              ),
+                            ].map((option) => (
+                              <option key={option} value={option}>
+                                {option}
+                              </option>
+                            ))}
                           </Select>
                         </FormField>
 
-                        <FormField label={tc('modals.feedback.form.details.label')}>
+                        <FormField
+                          label={tc('modals.feedback.form.details.label')}
+                        >
                           <Textarea name="text" name="message" />
                         </FormField>
                       </VStack>
@@ -280,16 +256,7 @@ function LayoutPage({
   );
 }
 
-const Header = ({ currentUser, currentHost, title, history }) => {
-  const UserStuff = () => (
-    <NotificationsPopup notifications={currentUser.notifications} />
-  );
-
-  const pathname = location.pathname;
-  const gotoPath = getGotoPath(pathname);
-
-  const isPage = pathname.substring(0, 5) === '/page';
-
+function Header({ currentUser, currentHost, title, history }) {
   return (
     <Box mb="4">
       <ScreenClassRender
@@ -346,9 +313,9 @@ const Header = ({ currentUser, currentHost, title, history }) => {
       />
     </Box>
   );
-};
+}
 
-const Menu = ({ currentHost, isMobile, screenClass, history }) => {
+function Menu({ currentHost, isMobile, screenClass, history }) {
   if (!currentHost || !currentHost.settings || !currentHost.settings.menu) {
     return null;
   }
@@ -422,9 +389,7 @@ const Menu = ({ currentHost, isMobile, screenClass, history }) => {
       </CMenu>
     </Box>
   );
-};
-
-const MobileMenu = ({}) => {};
+}
 
 export default withTracker((props) => {
   const hostSub = Meteor.subscribe('currentHost');

--- a/imports/ui/components/UserPopup.jsx
+++ b/imports/ui/components/UserPopup.jsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   Avatar,
+  AvatarBadge,
+  Badge,
   Box,
   Button,
   Menu,
@@ -17,8 +19,7 @@ import { StateContext } from '../LayoutContainer';
 import { userMenu, adminMenu } from '../@/constants/general';
 
 function UserPopup({ currentUser }) {
-
-  const [ tc ] = useTranslation('common');
+  const [tc] = useTranslation('common');
 
   if (!currentUser) {
     return (
@@ -32,6 +33,14 @@ function UserPopup({ currentUser }) {
     );
   }
 
+  const { notifications } = currentUser;
+  let notificationsCounter = 0;
+  if (notifications && notifications.length > 0) {
+    notifications.forEach((notification) => {
+      notificationsCounter += notification.count;
+    });
+  }
+
   const { role } = useContext(StateContext);
 
   return (
@@ -41,13 +50,26 @@ function UserPopup({ currentUser }) {
           mr="2"
           showBorder
           src={currentUser.avatar && currentUser.avatar.src}
-        />
+        >
+          <AvatarBadge borderColor="papayawhip" bg="tomato" boxSize=".7em" />
+        </Avatar>
       </MenuButton>
       <MenuList>
+        {notifications && notifications.length > 0 && (
+          <MenuGroup title={tc('menu.notifications.label')}>
+            {notifications.map((item) => (
+              <Link key={item.title} to={`/${item.context}/${item.contextId}`}>
+                <MenuItem>
+                  {item.title} <Badge>{item.count}</Badge>
+                </MenuItem>
+              </Link>
+            ))}
+          </MenuGroup>
+        )}
         <MenuGroup title={tc('menu.member.label')}>
           {userMenu.map((item) => (
             <Link key={item.key} to={item.value}>
-              <MenuItem>{tc('menu.member.'+item.key)}</MenuItem>
+              <MenuItem>{tc('menu.member.' + item.key)}</MenuItem>
             </Link>
           ))}
         </MenuGroup>
@@ -56,7 +78,7 @@ function UserPopup({ currentUser }) {
           <MenuGroup title={tc('menu.admin.label')}>
             {adminMenu.map((item) => (
               <Link key={item.key} to={item.value}>
-                <MenuItem>{tc('menu.admin.'+item.key)}</MenuItem>
+                <MenuItem>{tc('menu.admin.' + item.key)}</MenuItem>
               </Link>
             ))}
           </MenuGroup>

--- a/imports/ui/components/UserPopup.jsx
+++ b/imports/ui/components/UserPopup.jsx
@@ -58,9 +58,13 @@ function UserPopup({ currentUser }) {
         {notifications && notifications.length > 0 && (
           <MenuGroup title={tc('menu.notifications.label')}>
             {notifications.map((item) => (
-              <Link key={item.title} to={`/${item.context}/${item.contextId}`}>
+              <Link
+                key={item.contextId + item.count}
+                to={`/${item.context}/${item.contextId}`}
+              >
                 <MenuItem>
-                  {item.title} <Badge>{item.count}</Badge>
+                  {item.contextId}{' '}
+                  <Badge colorScheme="tomato">{item.count}</Badge>
                 </MenuItem>
               </Link>
             ))}

--- a/imports/ui/components/UserPopup.jsx
+++ b/imports/ui/components/UserPopup.jsx
@@ -43,6 +43,8 @@ function UserPopup({ currentUser }) {
 
   const { role } = useContext(StateContext);
 
+  const isNotification = notifications && notifications.length > 0;
+
   return (
     <Menu>
       <MenuButton>
@@ -51,11 +53,13 @@ function UserPopup({ currentUser }) {
           showBorder
           src={currentUser.avatar && currentUser.avatar.src}
         >
-          <AvatarBadge borderColor="papayawhip" bg="tomato" boxSize=".7em" />
+          {isNotification && (
+            <AvatarBadge borderColor="papayawhip" bg="tomato" boxSize=".7em" />
+          )}
         </Avatar>
       </MenuButton>
       <MenuList>
-        {notifications && notifications.length > 0 && (
+        {isNotification && (
           <MenuGroup title={tc('menu.notifications.label')}>
             {notifications.map((item) => (
               <Link
@@ -63,8 +67,7 @@ function UserPopup({ currentUser }) {
                 to={`/${item.context}/${item.contextId}`}
               >
                 <MenuItem>
-                  {item.contextId}{' '}
-                  <Badge colorScheme="tomato">{item.count}</Badge>
+                  {item.title} <Badge colorScheme="tomato">{item.count}</Badge>
                 </MenuItem>
               </Link>
             ))}

--- a/imports/ui/components/UserPopup.jsx
+++ b/imports/ui/components/UserPopup.jsx
@@ -13,6 +13,7 @@ import {
   MenuGroup,
   MenuItem,
   MenuList,
+  Text,
 } from '@chakra-ui/react';
 
 import { StateContext } from '../LayoutContainer';
@@ -67,7 +68,13 @@ function UserPopup({ currentUser }) {
                 to={`/${item.context}/${item.contextId}`}
               >
                 <MenuItem>
-                  {item.title} <Badge colorScheme="tomato">{item.count}</Badge>
+                  <Text color="gray.600" isTruncated>
+                    {item.title}{' '}
+                  </Text>
+                  <Badge colorScheme="red" size="xs">
+                    {' '}
+                    {item.count}
+                  </Badge>
                 </MenuItem>
               </Link>
             ))}

--- a/imports/ui/components/chattery/ChatteryBubble.jsx
+++ b/imports/ui/components/chattery/ChatteryBubble.jsx
@@ -52,12 +52,12 @@ class ChatteryBubble extends React.Component {
 
     return (
       <div className={bubbleClassContainer}>
-        <VisibilitySensor onChange={this.removeNotification}>
+        <VisibilitySensor
+          partialVisibility="bottom"
+          onChange={this.removeNotification}
+        >
           {({ isVisible }) => (
-            <div
-              className={bubbleClass}
-              // style={!isSeen ? { borderColor: '#ea3924' } : null}
-            >
+            <div className={bubbleClass}>
               <div className="talktext">
                 <p className="talktext-senderinfo">{senderUsername}</p>
                 <p className="talktext-content">{children}</p>

--- a/imports/ui/pages/processes/Process.jsx
+++ b/imports/ui/pages/processes/Process.jsx
@@ -8,7 +8,6 @@ import { Visible, ScreenClassRender } from 'react-grid-system';
 import renderHTML from 'react-render-html';
 import { useTranslation } from 'react-i18next';
 
-import { formatDate } from '../../@/shared.js';
 import DatePicker from '../../components/DatePicker.jsx';
 import {
   Accordion,
@@ -42,7 +41,6 @@ import Loader from '../../components/Loader';
 import FancyDate from '../../components/FancyDate';
 import NiceList from '../../components/NiceList';
 import InviteManager from './InviteManager';
-import { TimePicker } from '../../components/DatesAndTimes';
 import Template from '../../components/Template';
 import ConfirmModal from '../../components/ConfirmModal';
 import { message } from '../../components/message';
@@ -110,18 +108,19 @@ class Process extends Component {
     });
   };
 
-  addNewChatMessage = (message) => {
-    Meteor.call(
-      'addChatMessage',
-      this.props.process._id,
-      message,
-      (error, respond) => {
-        if (error) {
-          console.log('error', error);
-          message.error(error.error);
-        }
+  addNewChatMessage = (messageContent) => {
+    const { process } = this.props;
+    const values = {
+      context: 'process',
+      contextId: process._id,
+      message: messageContent,
+    };
+
+    Meteor.call('addChatMessage', values, (error, respond) => {
+      if (error) {
+        console.log('error', error);
       }
-    );
+    });
   };
 
   getChatMessages = () => {
@@ -471,7 +470,9 @@ class Process extends Component {
                 colorScheme={isAttending ? 'gray' : 'green'}
                 onClick={() => this.toggleAttendance(meetingIndex)}
               >
-                {isAttending ? t('meeting.isAttending.false') : t('meeting.isAttending.true')}
+                {isAttending
+                  ? t('meeting.isAttending.false')
+                  : t('meeting.isAttending.true')}
               </Button>
             </Center>
           </AccordionPanel>
@@ -482,7 +483,7 @@ class Process extends Component {
 
   handleFileDrop = (files) => {
     const { process, t, tc } = this.props;
-    
+
     if (files.length !== 1) {
       message.error(tc('plugins.fileDropper.single'));
       return;
@@ -527,7 +528,9 @@ class Process extends Component {
                       closeLoader();
                     } else {
                       message.success(
-                        `${uploadableFile.name} ${t('meeting.success.fileDropper')}`
+                        `${uploadableFile.name} ${t(
+                          'meeting.success.fileDropper'
+                        )}`
                       );
                       closeLoader();
                     }
@@ -821,7 +824,7 @@ class Process extends Component {
   };
 
   render() {
-    const { process, isLoading, resources, history , t, tc  } = this.props;
+    const { process, isLoading, resources, history, t, tc } = this.props;
 
     if (!process || isLoading) {
       return <Loader />;
@@ -918,16 +921,20 @@ class Process extends Component {
         </Template>
         <ConfirmModal
           visible={modalOpen}
-          title={t('confirm.title.text', { 
-            opt: isMember ? t('confirm.title.opts.leave') : t('confirm.title.opts.join')  
+          title={t('confirm.title.text', {
+            opt: isMember
+              ? t('confirm.title.opts.leave')
+              : t('confirm.title.opts.join'),
           })}
           onConfirm={isMember ? this.leaveProcess : this.joinProcess}
           onCancel={this.closeModal}
         >
           <Text>
-            {t('confirm.title.body', { 
-            opt: isMember ? t('confirm.title.opts.leave') : t('confirm.title.opts.join')  
-          })}
+            {t('confirm.title.body', {
+              opt: isMember
+                ? t('confirm.title.opts.leave')
+                : t('confirm.title.opts.join'),
+            })}
           </Text>
         </ConfirmModal>
         <ConfirmModal
@@ -937,13 +944,9 @@ class Process extends Component {
           onCancel={() => this.setState({ potentialNewAdmin: null })}
         >
           <Text>
-            <b>
-            {t('confirm.admin.title', { admin: potentialNewAdmin })}
-            </b>
+            <b>{t('confirm.admin.title', { admin: potentialNewAdmin })}</b>
           </Text>
-          <Text>
-            {t('confirm.admin.body', { admin: potentialNewAdmin })}
-          </Text>
+          <Text>{t('confirm.admin.body', { admin: potentialNewAdmin })}</Text>
         </ConfirmModal>
 
         {process && process.isPrivate && (
@@ -984,7 +987,7 @@ function CreateMeetingForm({
   buttonDisabled,
 }) {
   const [isLocal, setIsLocal] = useState(true);
-  const [ t ] = useTranslation('processes');
+  const [t] = useTranslation('processes');
 
   return (
     <Box p="2" bg="white" my="2">

--- a/imports/ui/pages/processes/Process.jsx
+++ b/imports/ui/pages/processes/Process.jsx
@@ -14,6 +14,7 @@ import {
   AccordionButton,
   AccordionItem,
   AccordionPanel,
+  Badge,
   Box,
   Button,
   Center,
@@ -228,7 +229,6 @@ class Process extends Component {
   };
 
   removeNotification = (messageIndex) => {
-    console.log(messageIndex);
     const { process, currentUser } = this.props;
     const shouldRun = currentUser.notifications?.find((notification) => {
       if (!notification.unSeenIndexes) {
@@ -735,9 +735,13 @@ class Process extends Component {
   };
 
   renderProcessInfo = () => {
-    const { process, chatData, t } = this.props;
+    const { process, chatData, currentUser, t } = this.props;
     const isAdmin = this.isAdmin();
     const isMember = this.isMember();
+    const isNotificationOn = process.isNotificationOn;
+    const notificationCount = currentUser.notifications.find(
+      (n) => (n.contextId = process._id)
+    )?.unSeenIndexes?.length;
 
     return (
       <div>
@@ -747,7 +751,10 @@ class Process extends Component {
             <Tabs variant="enclosed">
               <TabList pl="4">
                 <Tab>{t('tabs.process.info')}</Tab>
-                <Tab>{t('tabs.process.discuss')}</Tab>
+                <Tab>
+                  {t('tabs.process.discuss')}{' '}
+                  <Badge colorScheme="red">{notificationCount}</Badge>
+                </Tab>
               </TabList>
               <TabPanels>
                 <TabPanel>

--- a/imports/ui/pages/processes/Process.jsx
+++ b/imports/ui/pages/processes/Process.jsx
@@ -228,8 +228,9 @@ class Process extends Component {
   };
 
   removeNotification = (messageIndex) => {
+    console.log(messageIndex);
     const { process, currentUser } = this.props;
-    const shouldRun = currentUser.notifications.find((notification) => {
+    const shouldRun = currentUser.notifications?.find((notification) => {
       if (!notification.unSeenIndexes) {
         return false;
       }

--- a/imports/ui/pages/processes/Process.jsx
+++ b/imports/ui/pages/processes/Process.jsx
@@ -661,6 +661,7 @@ class Process extends Component {
         <Heading mb="2" size="sm">
           {t('labels.document')}
         </Heading>
+
         {process && process.documents && process.documents.length > 0 ? (
           <NiceList
             actionsDisabled={!isAdmin}
@@ -737,11 +738,9 @@ class Process extends Component {
   renderProcessInfo = () => {
     const { process, chatData, currentUser, t } = this.props;
     const isAdmin = this.isAdmin();
-    const isMember = this.isMember();
-    const isNotificationOn = process.isNotificationOn;
-    const notificationCount = currentUser.notifications.find(
-      (n) => (n.contextId = process._id)
-    )?.unSeenIndexes?.length;
+    const notificationCount = currentUser.notifications.find((n) => {
+      return n.contextId === process._id;
+    })?.unSeenIndexes?.length;
 
     return (
       <div>

--- a/imports/ui/pages/processes/Process.jsx
+++ b/imports/ui/pages/processes/Process.jsx
@@ -45,6 +45,7 @@ import InviteManager from './InviteManager';
 import Template from '../../components/Template';
 import ConfirmModal from '../../components/ConfirmModal';
 import { message } from '../../components/message';
+import { call } from '../../@/shared.js';
 
 moment.locale(i18n.language);
 
@@ -109,7 +110,7 @@ class Process extends Component {
     });
   };
 
-  addNewChatMessage = (messageContent) => {
+  addNewChatMessage = async (messageContent) => {
     const { process } = this.props;
     const values = {
       context: 'process',
@@ -117,11 +118,11 @@ class Process extends Component {
       message: messageContent,
     };
 
-    Meteor.call('addChatMessage', values, (error, respond) => {
-      if (error) {
-        console.log('error', error);
-      }
-    });
+    try {
+      await call('addChatMessage', values);
+    } catch (error) {
+      console.log('error', error);
+    }
   };
 
   getChatMessages = () => {

--- a/public/i18n/en/common.yml
+++ b/public/i18n/en/common.yml
@@ -54,7 +54,7 @@ message:
     min: '{{ field }} has to be at least {{ min }} characters'
 
 # MODAL POP-UPS
-modals: 
+modals:
   confirm:
     delete:
       title: Confirm Delete
@@ -62,12 +62,12 @@ modals:
       yes: Yes, delete
 
   # FEEDBACK FORM
-  feedback: 
+  feedback:
     label: Give Feedback
     form:
-      email: 
+      email:
         label: Your email address
-      subject: 
+      subject:
         label: Subject
         select:
           suggest: Suggestion
@@ -78,7 +78,7 @@ modals:
 
 # GUEST | MEMBER | ADMIN MENU LABELS
 menu:
-  guest: 
+  guest:
     login: Login
   member:
     label: My
@@ -91,6 +91,8 @@ menu:
     members: Members
     resources: Resources
     emails: Emails
+  notifications:
+    label: Notifications
 
 plugins:
   fileDropper:
@@ -116,7 +118,7 @@ domains:
 
   settings: Settings
   email: Email
-  
+
   account: account
   data: data
   avatar: avatar

--- a/public/i18n/sv/common.yml
+++ b/public/i18n/sv/common.yml
@@ -91,6 +91,8 @@ menu:
     members: Medlemmar
     resources: Resurser
     emails: E-postmeddelanden
+  notifications:
+    label: Aviseringar
 
 plugins:
   fileDropper:


### PR DESCRIPTION
So we now feature notifications for processes: A member of a process gets notifications for a process the member is part of, if there's any discussion that is going on in the process... 

The notifications design is simple and will be improved when new design will be implemented. For now, it appears under the avatar with a sign, if there's a notification, splitted regarding contexts (i.e. process title), with a badge showing the number of messages unseen.

In the future, we will follow up and implement notifications that don't only consume discussions; but also other things such as private process invites, and events, resource discussions, new user signup etc