### PR TITLE
Fix resource edit

### DIFF
--- a/imports/ui/components/Breadcrumb.jsx
+++ b/imports/ui/components/Breadcrumb.jsx
@@ -7,13 +7,13 @@ import {
   Center,
 } from '@chakra-ui/react';
 
-export default function Breadcrumb({ domain, domainKey }) {
+export default function Breadcrumb({ context, contextKey }) {
   const [breadcrumbs] = useState(window.location.pathname.split('/'));
   return (
     <Center py="4">
       <BreadcrumbMenu>
         {breadcrumbs.map((item, index) => {
-          if (domain?._id == item) item = domain[domainKey];
+          if (context?._id == item) item = context[contextKey];
           item = item.charAt(0).toUpperCase() + item.slice(1);
           if (item == '' && index == 0)
             return (

--- a/imports/ui/pages/resources/EditResource.jsx
+++ b/imports/ui/pages/resources/EditResource.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Box, Center, Button } from '@chakra-ui/react';
 import { useTranslation } from 'react-i18next';
 
+import { StateContext } from '../../LayoutContainer';
 import { call } from '../../utils/shared';
 import { message } from '../../components/message';
 import NotFoundPage from '../NotFoundPage';
@@ -10,8 +11,10 @@ import Template from '../../components/Template';
 import Breadcrumb from '../../components/Breadcrumb';
 import ResourceForm from './components/ResourceForm';
 import ConfirmModal from '../../components/ConfirmModal';
+import { Alert } from '../../components/message';
 
 function EditResourcePage({ history }) {
+  const { role } = useContext(StateContext);
   const { resourceId } = useParams();
   const [resource, setResource] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -46,8 +49,17 @@ function EditResourcePage({ history }) {
     }
   };
 
-  if (typeof resource === 'undefined')
+  if (role !== 'admin') {
+    return <Alert message={tc('message.access.deny')} type="error" />;
+  }
+
+  if (typeof resource === 'undefined') {
     return <NotFoundPage domain="Resource with this name or id" />;
+  }
+
+  if (!resource) {
+    return null;
+  }
 
   return (
     <Template heading={tc('labels.update', { domain: tc('domains.resource') })}>

--- a/imports/ui/pages/resources/Resource.jsx
+++ b/imports/ui/pages/resources/Resource.jsx
@@ -21,7 +21,7 @@ function ResourcePage() {
   const [resource, setResource] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
   const [tc] = useTranslation('common');
-  const { currentUser, canCreateContent } = useContext(StateContext);
+  const { canCreateContent, currentUser, role } = useContext(StateContext);
   const { isChatLoading, discussion } = useChattery(resourceId, currentUser);
 
   useEffect(() => {
@@ -95,13 +95,16 @@ function ResourcePage() {
               resource={resource}
             />
             {isMobile && <DocumentsField contextType="resource" contextId={resource?._id} />}
-            <Center my="2">
-              <Link to={`/resources/${resource?._id}/edit`}>
-                <Button size="sm" variant="ghost">
-                  {tc('actions.update')}
-                </Button>
-              </Link>
-            </Center>
+
+            {role === 'admin' && (
+              <Center my="2">
+                <Link to={`/resources/${resource?._id}/edit`}>
+                  <Button size="sm" variant="ghost">
+                    {tc('actions.update')}
+                  </Button>
+                </Link>
+              </Center>
+            )}
           </Template>
         );
       }}


### PR DESCRIPTION
Resource edit button and the edit page appeared to non-logged in users, whereas it should only be visible by admins.
This pr fixes that, as well as a bonus for fixing the viewing of the resource label instead of id on the breadcrumb.

